### PR TITLE
Only publish online users

### DIFF
--- a/client/Lobby/Lobby.js
+++ b/client/Lobby/Lobby.js
@@ -7,7 +7,7 @@ Template.Lobby.helpers({
  },
  'usersOnline': function() {
    var currentUserId = Meteor.userId()
-   return Meteor.users.find({ "status.online": true, _id: { $ne: currentUserId } }, )
+   return Meteor.users.find({ _id: { $ne: currentUserId } } )
  }
 });
 
@@ -15,7 +15,7 @@ Template.User.helpers({
   'character'(){
     var characterId = this.characterId;
     var char = Characters.findOne( characterId );
-    
+
     return char.name;
   }
 });

--- a/server/publish.js
+++ b/server/publish.js
@@ -3,5 +3,5 @@ Meteor.publish('characters', function(){
 });
 
 Meteor.publish("userStatus", function() {
-  return Meteor.users.find();
+  return Meteor.users.find({"status.online": true});
 });


### PR DESCRIPTION
One of the security features for meteor is that you should only publish the data the clients need - so I changed the userStatus publication to only publish users online, because that is the only data the client needs - not our full user list...

Tests all still passing